### PR TITLE
chore: Omit Fedora 30

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,10 +60,6 @@ jobs:
           env:
             - FROM='fedora:31'
         - os: linux
-          name: "Fedora 30"
-          env:
-            - FROM='fedora:30'
-        - os: linux
           name: "CentOS 8"
           env:
             - FROM='centos:8'


### PR DESCRIPTION
Remove Fedora 30 from the list of docker images we build in CI.