### PR TITLE
Feature: Add Fedora 33

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,10 @@ jobs:
           env:
             - FROM='opensuse/leap'
         - os: linux
+          name: "Fedora 33"
+          env:
+            - FROM='fedora:33'
+        - os: linux
           name: "Fedora 32"
           env:
             - FROM='fedora:32'

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -25,7 +25,7 @@
 set -e
 
 echo "------------------------------"
-echo "--- bootstrap | 2020-08-22 ---"
+echo "--- bootstrap | 2020-10-28 ---"
 echo "------------------------------"
 
 if [ -f /etc/os-release ]
@@ -217,7 +217,7 @@ then
                             git \
                             rpm-build \
                             clang
-elif [ $LINUX_ID == "fedora" ] && [ $LINUX_VERSION_ID -eq 32 ]
+elif [ $LINUX_ID == "fedora" ] && ([ $LINUX_VERSION_ID -ge 32 ] && [ $LINUX_VERSION_ID -lt 34 ])
 then
     dnf install -y \
                         git \

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -60,7 +60,6 @@ then
                     libpng-tools \
                     libjpeg62-turbo-dev \
                     libexpat1-dev \
-                    libgtk2.0-dev \
                     libgtk-3-dev \
                     libopenal-dev \
                     libogg-dev \
@@ -90,7 +89,6 @@ then
                     libpng-tools \
                     libjpeg62-turbo-dev \
                     libexpat1-dev \
-                    libgtk2.0-dev \
                     libgtk-3-dev \
                     libopenal-dev \
                     libogg-dev \
@@ -120,7 +118,6 @@ then
                     libpng-tools \
                     libjpeg62-dev \
                     libexpat1-dev \
-                    libgtk2.0-dev \
                     libgtk-3-dev \
                     libopenal-dev \
                     libogg-dev \
@@ -151,7 +148,6 @@ then
                     libvorbis-dev \
                     libjpeg-dev \
                     libpng-dev \
-                    libgtk2.0-dev \
                     libgtk-3-dev \
                     libboost-python-dev \
                     libboost-log-dev \
@@ -174,7 +170,6 @@ then
                     libvorbis-dev \
                     libjpeg-dev \
                     libpng-dev \
-                    libgtk2.0-dev \
                     libgtk-3-dev \
                     libboost-python-dev \
                     libboost-log-dev \
@@ -208,8 +203,6 @@ then
                             libpng16-devel \
                             expat \
                             libexpat-devel \
-                            libgtk-2_0-0 \
-                            gtk2-devel \
                             libgtk-3-0 \
                             gtk3-devel \
                             python-devel \
@@ -232,7 +225,6 @@ then
                         libjpeg-turbo-devel \
                         libpng-devel \
                         expat-devel \
-                        gtk2-devel \
                         gtk3-devel \
                         python3-devel \
                         rpm-build \
@@ -254,7 +246,6 @@ then
                         libjpeg-turbo-devel \
                         libpng-devel \
                         expat-devel \
-                        gtk2-devel \
                         gtk3-devel \
                         python2-devel \
                         python3-devel \
@@ -279,7 +270,6 @@ then
                         libjpeg-turbo-devel \
                         libpng-devel \
                         expat-devel \
-                        gtk2-devel \
                         gtk3-devel \
                         python3-devel \
                         rpm-build \
@@ -303,7 +293,6 @@ then
                         libjpeg-turbo-devel \
                         libpng-devel \
                         expat-devel \
-                        gtk2-devel \
                         gtk3-devel \
                         python3-devel \
                         rpm-build \


### PR DESCRIPTION
Add Fedora 33 to the build system images that we build. Also remove GTK 2.0 from the list of dependencies -- it is not required past Vega Strike 0.6.x.