### PR TITLE
Security of GH Secrets

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# GitHub Security
+* @vegastrike/vegastrike-infrastructure-admins
+
+.github/ @vegastrike/vegastrike-infrastructure-admins

--- a/.github/workflows/gh-actions-release.yml
+++ b/.github/workflows/gh-actions-release.yml
@@ -6,10 +6,13 @@ on:
       - created
       - edited
 
+
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    environment:
+      name: production
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
- Protect the files under .github so not just anyone can change them
- Moved the GH Secrets used by the release action to an environment
  so they can only be used under limited access

Thank you for submitting a pull request and becoming a contributor to Vega Strike's Build System Docker Images.

Please answer the following:

Code Changes:
- [ ] This is a documentation change only
- [x] CI Change

Issues:
- https://github.blog/2021-04-13-implementing-least-privilege-for-secrets-in-github-actions/

Purpose:
Apply security restrictions to the GH Secrets.