### PR TITLE
script/bootstrap: Tighten up which versions of openSUSE are recognized

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -306,7 +306,7 @@ then
                     libxmu-dev \
                     clang \
                     lsb-release
-elif [ $LINUX_ID == "opensuse-leap" ] && ([ $(echo ${LINUX_VERSION_ID} | cut -f 1 -d '.') -eq 15 ] || [ $(echo ${LINUX_VERSION_ID} | cut -f 2 -d '.') -ge 2 ])
+elif [ $LINUX_ID == "opensuse-leap" ] && ([ $(echo ${LINUX_VERSION_ID} | cut -f 1 -d '.') -eq 15 ] && [ $(echo ${LINUX_VERSION_ID} | cut -f 2 -d '.') -ge 2 ])
 then
     zypper --non-interactive install -y \
                             libboost_log1_66_0-devel \

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -25,7 +25,7 @@
 set -e
 
 echo "------------------------------"
-echo "--- bootstrap | 2021-07-28 ---"
+echo "--- bootstrap | 2021-08-01 ---"
 echo "------------------------------"
 
 if [ -f /etc/os-release ]
@@ -306,7 +306,7 @@ then
                     libxmu-dev \
                     clang \
                     lsb-release
-elif [ $LINUX_ID == "opensuse-leap" ]
+elif [ $LINUX_ID == "opensuse-leap" ] && ([ $LINUX_VERSION_ID == "15.2" ] || [ $LINUX_VERSION_ID == "15.3" ])
 then
     zypper --non-interactive install -y \
                             libboost_log1_66_0-devel \

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -306,7 +306,7 @@ then
                     libxmu-dev \
                     clang \
                     lsb-release
-elif [ $LINUX_ID == "opensuse-leap" ] && ([ $LINUX_VERSION_ID == "15.2" ] || [ $LINUX_VERSION_ID == "15.3" ])
+elif [ $LINUX_ID == "opensuse-leap" ] && ([ $(echo ${LINUX_VERSION_ID} | cut -f 1 -d '.') -eq 15 ] || [ $(echo ${LINUX_VERSION_ID} | cut -f 2 -d '.') -ge 2 ])
 then
     zypper --non-interactive install -y \
                             libboost_log1_66_0-devel \


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to Vega Strike's Build System Docker Images.

Please answer the following:

Code Changes:
- [ ] This is a documentation change only
- [ ] CI Change

Issues:
- Please list any related issues
N/A

Purpose:
- What is this pull request trying to do? Restrict the allowed versions of openSUSE "Leap" to only those which we know how to build on properly, namely 15.2 and 15.3.
- What release is this for? Upcoming
- Is there a project or milestone we should apply this to? Not particularly
