### PR TITLE
Boost, CMake, py2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.editorconfig

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -234,7 +234,6 @@ then
     apt-get -qy upgrade
     apt-get -qy install \
                     git \
-                    cmake \
                     build-essential \
                     python-dev \
                     libgl1-mesa-glx \
@@ -251,6 +250,7 @@ then
                     libxmu-dev \
                     clang \
                     lsb-release
+    snap install cmake --classic
 elif [ $LINUX_ID == "ubuntu" ] && [ $LINUX_CODENAME == "xenial" ]
 then
     apt-get update

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,11 +1,11 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #====================================
 # @file   : bootstrap
 # @brief  : installs dependencies for building Vega Strike
 # @usage  : sudo script/bootstrap
 # @param  : none
 #====================================
-# Copyright (C) 2020-2021 Stephen G. Tuggy <sgt@stephengtuggy.com>
+# Copyright (C) 2020-2021 Stephen G. Tuggy
 #
 # This file is part of Vega Strike.
 #

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -25,7 +25,7 @@
 set -e
 
 echo "------------------------------"
-echo "--- bootstrap | 2021-08-01 ---"
+echo "--- bootstrap | 2021-08-29 ---"
 echo "------------------------------"
 
 if [ -f /etc/os-release ]
@@ -99,9 +99,9 @@ then
                     libsdl1.2-dev \
                     libpostproc-dev \
                     freeglut3-dev \
-                    libboost-python1.67-dev \
-                    libboost-log1.67-dev \
-                    libboost-regex1.67-dev \
+                    libboost-python-dev \
+                    libboost-log-dev \
+                    libboost-regex-dev \
                     libxmu-dev \
                     clang \
                     lsb-release
@@ -222,9 +222,9 @@ then
                     libopengl0 \
                     libpostproc-dev \
                     freeglut3-dev \
-                    libboost-python1.67-dev \
-                    libboost-log1.67-dev \
-                    libboost-regex1.67-dev \
+                    libboost-python-dev \
+                    libboost-log-dev \
+                    libboost-regex-dev \
                     libxmu-dev \
                     clang \
                     lsb-release
@@ -300,9 +300,9 @@ then
                     libopengl0 \
                     libpostproc-dev \
                     freeglut3-dev \
-                    libboost-python1.67-dev \
-                    libboost-log1.67-dev \
-                    libboost-regex1.67-dev \
+                    libboost-python-dev \
+                    libboost-log-dev \
+                    libboost-regex-dev \
                     libxmu-dev \
                     clang \
                     lsb-release

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -82,7 +82,6 @@ then
     apt-get -qy install \
                     git \
                     cmake \
-                    python-dev \
                     build-essential \
                     automake \
                     autoconf \
@@ -112,7 +111,6 @@ then
     apt-get -qy install \
                     git \
                     cmake \
-                    python-dev \
                     build-essential \
                     automake \
                     autoconf \
@@ -204,7 +202,6 @@ then
     apt-get -qy install \
                     git \
                     cmake \
-                    python-dev \
                     build-essential \
                     automake \
                     autoconf \
@@ -236,7 +233,6 @@ then
                     git \
                     cmake \
                     build-essential \
-                    python-dev \
                     libgl1-mesa-glx \
                     freeglut3-dev \
                     libopenal-dev \
@@ -259,7 +255,6 @@ then
                     git \
                     cmake \
                     build-essential \
-                    python-dev \
                     libgl1-mesa-glx \
                     freeglut3-dev \
                     libopenal-dev \
@@ -282,7 +277,6 @@ then
     apt-get -qy install \
                     git \
                     cmake \
-                    python-dev \
                     build-essential \
                     automake \
                     autoconf \
@@ -332,7 +326,6 @@ then
                             libexpat-devel \
                             libgtk-3-0 \
                             gtk3-devel \
-                            python-devel \
                             python3-devel \
                             git \
                             rpm-build \

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -249,7 +249,8 @@ then
                     libboost-regex-dev \
                     libxmu-dev \
                     clang \
-                    lsb-release
+                    lsb-release \
+                    snapd
     snap install cmake --classic
 elif [ $LINUX_ID == "ubuntu" ] && [ $LINUX_CODENAME == "xenial" ]
 then

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -435,7 +435,7 @@ then
                         rpm-build \
                         make \
                         clang
-elif [ $LINUX_ID == "rocky" ] && [ $LINUX_VERSION_ID == "8.4" ]
+elif [ $LINUX_ID == "rocky" ] && ([ $(echo ${LINUX_VERSION_ID} | cut -f 1 -d '.') -eq 8 ] && [ $(echo ${LINUX_VERSION_ID} | cut -f 2 -d '.') -ge 4 ])
 then
     dnf -y install dnf-plugins-core
     dnf -y install epel-release

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -231,7 +231,6 @@ then
     apt-get -qy upgrade
     apt-get -qy install \
                     git \
-                    cmake \
                     build-essential \
                     libgl1-mesa-glx \
                     freeglut3-dev \
@@ -246,7 +245,9 @@ then
                     libboost-regex-dev \
                     libxmu-dev \
                     clang \
-                    lsb-release
+                    lsb-release \
+                    python3-pip
+    pip3 install --upgrade-strategy eager cmake
 elif [ $LINUX_ID == "ubuntu" ] && [ $LINUX_CODENAME == "xenial" ]
 then
     apt-get update

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -251,7 +251,7 @@ then
                     clang \
                     lsb-release \
                     snapd
-    service snapd start
+    service snapd.service start
     snap install cmake --classic
 elif [ $LINUX_ID == "ubuntu" ] && [ $LINUX_CODENAME == "xenial" ]
 then

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -234,6 +234,7 @@ then
     apt-get -qy upgrade
     apt-get -qy install \
                     git \
+                    cmake \
                     build-essential \
                     python-dev \
                     libgl1-mesa-glx \
@@ -249,10 +250,7 @@ then
                     libboost-regex-dev \
                     libxmu-dev \
                     clang \
-                    lsb-release \
-                    snapd
-    service snapd.service start
-    snap install cmake --classic
+                    lsb-release
 elif [ $LINUX_ID == "ubuntu" ] && [ $LINUX_CODENAME == "xenial" ]
 then
     apt-get update

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -310,7 +310,6 @@ elif [ $LINUX_ID == "opensuse-leap" ] && ([ $(echo ${LINUX_VERSION_ID} | cut -f 
 then
     zypper --non-interactive install -y \
                             libboost_log1_66_0-devel \
-                            libboost_python-py2_7-1_66_0-devel \
                             libboost_python-py3-1_66_0-devel \
                             libboost_system1_66_0-devel \
                             libboost_filesystem1_66_0-devel \
@@ -383,7 +382,6 @@ then
                         git \
                         cmake \
                         boost-devel \
-                        boost-python2-devel \
                         boost-python3-devel \
                         freeglut-devel \
                         gcc-c++ \
@@ -394,7 +392,6 @@ then
                         libpng-devel \
                         expat-devel \
                         gtk3-devel \
-                        python2-devel \
                         python3-devel \
                         rpm-build \
                         make \

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -251,6 +251,7 @@ then
                     clang \
                     lsb-release \
                     snapd
+    systemctl start snapd.service
     snap install cmake --classic
 elif [ $LINUX_ID == "ubuntu" ] && [ $LINUX_CODENAME == "xenial" ]
 then

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -251,7 +251,7 @@ then
                     clang \
                     lsb-release \
                     snapd
-    systemctl start snapd.service
+    service snapd start
     snap install cmake --classic
 elif [ $LINUX_ID == "ubuntu" ] && [ $LINUX_CODENAME == "xenial" ]
 then

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,12 +1,11 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #====================================
 # @file   : cibuild
-# @brief  : Builds the docker images
-#           in the context of CI/CD (Travis)
+# @brief  : Builds the docker images in the context of CI/CD (GitHub Actions)
 # @usage  : script/cibuild
 # @param  : none
 #====================================
-# Copyright (C) 2020 Stephen G. Tuggy <sgt@stephengtuggy.com>
+# Copyright (C) 2020-2021 Stephen G. Tuggy
 #
 # This file is part of Vega Strike.
 #


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to Vega Strike's Build System Docker Images.

Please answer the following:

Code Changes:
- [ ] This is a documentation change only
- [X] CI Change

Issues:
- Closes #21 
- Closes #22 
- Closes #23 

Purpose:
- Use default version of Boost -- 1.71.0 instead of 1.67.0 -- on Ubuntu 20.04 "focal", Debian 10 "buster", and Linux Mint 20 "ulyana"
- Install CMake from `pip` instead of using `apt`, where needed. Turns out this is only needed under Ubuntu 18.04 "bionic"
- Stop explicitly depending on py2

What release is this for? 0.8.x and following
- Is there a project or milestone we should apply this to? 0.8.x and 0.9.x/1.0.x, I believe
