### PR TITLE
bootstrap, *.yml: Retire Debian "stretch"

### DIFF
--- a/.github/workflows/Anchore-Container-Scan.yml
+++ b/.github/workflows/Anchore-Container-Scan.yml
@@ -31,7 +31,6 @@ jobs:
           - FROM:     'debian:bookworm'
           - FROM:     'debian:bullseye'
           - FROM:     'debian:buster'
-          - FROM:     'debian:stretch'
           - FROM:     'opensuse/leap'
           - FROM:     'opensuse/leap:15.4'
           - FROM:     'opensuse/leap:15.3'

--- a/.github/workflows/gh-actions-pr.yml
+++ b/.github/workflows/gh-actions-pr.yml
@@ -21,7 +21,6 @@ jobs:
           - FROM:     'debian:bookworm'
           - FROM:     'debian:bullseye'
           - FROM:     'debian:buster'
-          - FROM:     'debian:stretch'
           - FROM:     'opensuse/leap'
           - FROM:     'opensuse/leap:15.4'
           - FROM:     'opensuse/leap:15.3'

--- a/.github/workflows/gh-actions-release.yml
+++ b/.github/workflows/gh-actions-release.yml
@@ -28,7 +28,6 @@ jobs:
           - FROM:     'debian:bookworm'
           - FROM:     'debian:bullseye'
           - FROM:     'debian:buster'
-          - FROM:     'debian:stretch'
           - FROM:     'opensuse/leap'
           - FROM:     'opensuse/leap:15.4'
           - FROM:     'opensuse/leap:15.3'

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -29,7 +29,7 @@
 set -e
 
 echo "------------------------------"
-echo "--- bootstrap | 2023-03-05 ---"
+echo "--- bootstrap | 2023-05-14 ---"
 echo "------------------------------"
 
 UPDATE_ALL_SYSTEM_PACKAGES="$1"

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -154,34 +154,8 @@ function bootstrapOnDebian()
       apt-get -qy install cmake -t buster-backports
       ;;
     "stretch")
-      apt-get -qy install \
-                      git \
-                      build-essential \
-                      automake \
-                      autoconf \
-                      libpng16-16 \
-                      libpng-dev \
-                      libpng-tools \
-                      libjpeg62-turbo-dev \
-                      libexpat1-dev \
-                      libgtk-3-dev \
-                      libopenal-dev \
-                      libogg-dev \
-                      libvorbis-dev \
-                      libgl1-mesa-dev \
-                      libsdl1.2-dev \
-                      libpostproc-dev \
-                      freeglut3-dev \
-                      libboost-python-dev \
-                      libboost-log-dev \
-                      libboost-regex-dev \
-                      libboost-program-options-dev \
-                      libxmu-dev \
-                      clang \
-                      lsb-release \
-                      python3-pip
-      python3 -m pip install --upgrade-strategy eager --upgrade pip
-      python3 -m pip install --upgrade-strategy eager cmake
+      echo "Sorry, Debian stretch is no longer supported"
+      exit 2
       ;;
     *)
       echo "Sorry, this version of Debian is unsupported"


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to Vega Strike's Build System Docker Images.

Please answer the following:

Code Changes:
- [ ] This is a documentation change only
- [X] CI Change

Issues:
- Please list any related issues

Purpose:
- What is this pull request trying to do? Retire Debian "stretch", since updates no longer seem to be available for it
- What release is this for? Any
- Is there a project or milestone we should apply this to? Not sure
