### PR TITLE
Remove ubuntu impish and hirsute build images

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -232,69 +232,6 @@ function bootstrapOnUbuntu()
                       clang \
                       lsb-release
       ;;
-    "impish")
-      apt-get -qy install \
-                      git \
-                      cmake \
-                      python3-dev \
-                      build-essential \
-                      automake \
-                      autoconf \
-                      libpng16-16 \
-                      libpng-dev \
-                      libpng-tools \
-                      libjpeg-turbo8-dev \
-                      libexpat1-dev \
-                      libgdk-pixbuf-2.0-dev \
-                      libgtk-3-dev \
-                      libopenal-dev \
-                      libogg-dev \
-                      libvorbis-dev \
-                      libglvnd-dev \
-                      libgl1-mesa-dev \
-                      libsdl1.2-dev \
-                      libopengl0 \
-                      libpostproc-dev \
-                      freeglut3-dev \
-                      libboost-python-dev \
-                      libboost-log-dev \
-                      libboost-regex-dev \
-                      libboost-program-options-dev \
-                      libxmu-dev \
-                      clang \
-                      lsb-release
-      ;;
-    "hirsute")
-      apt-get -qy install \
-                      git \
-                      cmake \
-                      python3-dev \
-                      build-essential \
-                      automake \
-                      autoconf \
-                      libpng16-16 \
-                      libpng-dev \
-                      libpng-tools \
-                      libjpeg62-dev \
-                      libexpat1-dev \
-                      libgtk-3-dev \
-                      libopenal-dev \
-                      libogg-dev \
-                      libvorbis-dev \
-                      libglvnd-dev \
-                      libgl1-mesa-dev \
-                      libsdl1.2-dev \
-                      libopengl0 \
-                      libpostproc-dev \
-                      freeglut3-dev \
-                      libboost-python-dev \
-                      libboost-log-dev \
-                      libboost-regex-dev \
-                      libboost-program-options-dev \
-                      libxmu-dev \
-                      clang \
-                      lsb-release
-      ;;
     "groovy")
       apt-get -qy install \
                       git \

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -317,6 +317,14 @@ function bootstrapOnUbuntu()
       python3 -m pip install --upgrade-strategy eager --upgrade pip
       python3 -m pip install --upgrade-strategy eager cmake
       ;;
+    "impish")
+      echo "Sorry, Ubuntu impish is no longer supported"
+      exit 2
+      ;;
+    "hirsute")
+      echo "Sorry, Ubuntu hirsute is no longer supported"
+      exit 2
+      ;;
     "xenial")
       echo "Sorry, Ubuntu xenial is no longer supported"
       exit 2


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to Vega Strike's Build System Docker Images.

Please answer the following:

Code Changes:
- [ ] This is a documentation change only
- [x] CI Change

Issues:
- Not related to any issue, just clean-up during  #713

Purpose:
- Remove build images for unsupported Ubuntu versions
