### PR TITLE
Enhancement: SDL2 support

### DIFF
--- a/.github/workflows/Anchore-Container-Scan.yml
+++ b/.github/workflows/Anchore-Container-Scan.yml
@@ -22,7 +22,6 @@ jobs:
       matrix:
         FROM:
           - 'ubuntu:lunar'
-          - 'ubuntu:kinetic'
           - 'ubuntu:jammy'
           - 'ubuntu:focal'
           - 'ubuntu:bionic'

--- a/.github/workflows/gh-actions-pr.yml
+++ b/.github/workflows/gh-actions-pr.yml
@@ -12,7 +12,6 @@ jobs:
       matrix:
         FROM:
           - 'ubuntu:lunar'
-          - 'ubuntu:kinetic'
           - 'ubuntu:jammy'
           - 'ubuntu:focal'
           - 'ubuntu:bionic'

--- a/.github/workflows/gh-actions-release.yml
+++ b/.github/workflows/gh-actions-release.yml
@@ -19,7 +19,6 @@ jobs:
       matrix:
         FROM:
           - 'ubuntu:lunar'
-          - 'ubuntu:kinetic'
           - 'ubuntu:jammy'
           - 'ubuntu:focal'
           - 'ubuntu:bionic'

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .editorconfig
+*.sw?

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -210,39 +210,6 @@ function bootstrapOnUbuntu()
                       clang \
                       lsb-release
       ;;
-    "kinetic")
-      apt-get -qy install \
-                      git \
-                      cmake \
-                      python3-dev \
-                      build-essential \
-                      automake \
-                      autoconf \
-                      libpng16-16 \
-                      libpng-dev \
-                      libpng-tools \
-                      libjpeg-turbo8-dev \
-                      libexpat1-dev \
-                      libgdk-pixbuf-2.0-dev \
-                      libgtk-3-dev \
-                      libopenal-dev \
-                      libogg-dev \
-                      libvorbis-dev \
-                      libglvnd-dev \
-                      libgl1-mesa-dev \
-                      libsdl1.2-dev \
-                      libsdl2-dev \
-                      libopengl0 \
-                      libpostproc-dev \
-                      freeglut3-dev \
-                      libboost-python-dev \
-                      libboost-log-dev \
-                      libboost-regex-dev \
-                      libboost-program-options-dev \
-                      libxmu-dev \
-                      clang \
-                      lsb-release
-      ;;
     "jammy")
       apt-get -qy install \
                       git \

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -81,6 +81,7 @@ function bootstrapOnDebian()
                       libglvnd-dev \
                       libgl1-mesa-dev \
                       libsdl1.2-dev \
+                      libsdl2-dev \
                       libpostproc-dev \
                       freeglut3-dev \
                       libboost-python-dev \
@@ -110,6 +111,7 @@ function bootstrapOnDebian()
                       libglvnd-dev \
                       libgl1-mesa-dev \
                       libsdl1.2-dev \
+                      libsdl2-dev \
                       libpostproc-dev \
                       freeglut3-dev \
                       libboost-python-dev \
@@ -137,6 +139,7 @@ function bootstrapOnDebian()
                       libglvnd-dev \
                       libgl1-mesa-dev \
                       libsdl1.2-dev \
+                      libsdl2-dev \
                       libpostproc-dev \
                       freeglut3-dev \
                       libboost-python-dev \
@@ -167,6 +170,7 @@ function bootstrapOnDebian()
                       libvorbis-dev \
                       libgl1-mesa-dev \
                       libsdl1.2-dev \
+                      libsdl2-dev \
                       libpostproc-dev \
                       freeglut3-dev \
                       libboost-python-dev \
@@ -217,6 +221,7 @@ function bootstrapOnUbuntu()
                       libglvnd-dev \
                       libgl1-mesa-dev \
                       libsdl1.2-dev \
+                      libsdl2-dev \
                       libopengl0 \
                       libpostproc-dev \
                       freeglut3-dev \
@@ -248,6 +253,7 @@ function bootstrapOnUbuntu()
                       libglvnd-dev \
                       libgl1-mesa-dev \
                       libsdl1.2-dev \
+                      libsdl2-dev \
                       libopengl0 \
                       libpostproc-dev \
                       freeglut3-dev \
@@ -278,6 +284,7 @@ function bootstrapOnUbuntu()
                       libglvnd-dev \
                       libgl1-mesa-dev \
                       libsdl1.2-dev \
+                      libsdl2-dev \
                       libopengl0 \
                       libpostproc-dev \
                       freeglut3-dev \
@@ -308,6 +315,7 @@ function bootstrapOnUbuntu()
                       libglvnd-dev \
                       libgl1-mesa-dev \
                       libsdl1.2-dev \
+                      libsdl2-dev \
                       libopengl0 \
                       libpostproc-dev \
                       freeglut3-dev \
@@ -337,6 +345,7 @@ function bootstrapOnUbuntu()
                       libglvnd-dev \
                       libgl1-mesa-dev \
                       libsdl1.2-dev \
+                      libsdl2-dev \
                       libopengl0 \
                       libpostproc-dev \
                       freeglut3-dev \
@@ -356,6 +365,7 @@ function bootstrapOnUbuntu()
                       freeglut3-dev \
                       libopenal-dev \
                       libsdl-gfx1.2-dev \
+                      libsdl2-dev \
                       libvorbis-dev \
                       libjpeg-dev \
                       libpng-dev \
@@ -412,6 +422,7 @@ function bootstrapOnPopOS ()
                       libglvnd-dev \
                       libgl1-mesa-dev \
                       libsdl1.2-dev \
+                      libsdl2-dev \
                       libopengl0 \
                       libpostproc-dev \
                       freeglut3-dev \
@@ -460,6 +471,7 @@ function bootstrapOnLinuxMint ()
                       libglvnd-dev \
                       libgl1-mesa-dev \
                       libsdl1.2-compat-dev \
+                      libsdl2-dev \
                       libopengl0 \
                       libpostproc-dev \
                       freeglut3-dev \
@@ -491,6 +503,7 @@ function bootstrapOnLinuxMint ()
                       libglvnd-dev \
                       libgl1-mesa-dev \
                       libsdl1.2-dev \
+                      libsdl2-dev \
                       libopengl0 \
                       libpostproc-dev \
                       freeglut3-dev \
@@ -520,6 +533,7 @@ function bootstrapOnLinuxMint ()
                       libglvnd-dev \
                       libgl1-mesa-dev \
                       libsdl1.2-dev \
+                      libsdl2-dev \
                       libopengl0 \
                       libpostproc-dev \
                       freeglut3-dev \

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -154,34 +154,8 @@ function bootstrapOnDebian()
       apt-get -qy install cmake -t buster-backports
       ;;
     "stretch")
-      apt-get -qy install \
-                      git \
-                      build-essential \
-                      automake \
-                      autoconf \
-                      libpng16-16 \
-                      libpng-dev \
-                      libpng-tools \
-                      libjpeg62-turbo-dev \
-                      libexpat1-dev \
-                      libgtk-3-dev \
-                      libopenal-dev \
-                      libogg-dev \
-                      libvorbis-dev \
-                      libgl1-mesa-dev \
-                      libsdl1.2-dev \
-                      libsdl2-dev \
-                      libpostproc-dev \
-                      freeglut3-dev \
-                      libboost-python-dev \
-                      libboost-log-dev \
-                      libboost-regex-dev \
-                      libxmu-dev \
-                      clang \
-                      lsb-release \
-                      python3-pip
-      python3 -m pip install --upgrade-strategy eager --upgrade pip
-      python3 -m pip install --upgrade-strategy eager cmake
+      echo "Sorry, Debian stretch is no longer supported"
+      exit 2
       ;;
     *)
       echo "Sorry, this version of Debian is unsupported"

--- a/script/local-test-ci.sh
+++ b/script/local-test-ci.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+export FROM="debian:bullseye"
+export MY_OS_NAME="linux"
+export IS_RELEASE=0
+
+#./script/cibuild
+export DOCKER_IMG_NAME="vegastrike/vega-strike-build-env:$(echo "$FROM" | sed 's/:/_/' | sed 's/\//_/')"
+docker build --build-arg from="$FROM" -t "$DOCKER_IMG_NAME" .


### PR DESCRIPTION
Vega Strike is moving to use SDL2. Add support to the docker images for SDL2 in addition to SDL1.

- add a tool to easily check that the script works locally
- ignore Vi Swap files

Thank you for submitting a pull request and becoming a contributor to Vega Strike's Build System Docker Images.

Please answer the following:

Code Changes:
- [ ] This is a documentation change only
- [x] CI Change

Issues:
- [VS Engine SDL2 Support](https://github.com/vegastrike/Vega-Strike-Engine-Source/pull/792)

Purpose:
- What is this pull request trying to do? Adds SDL2 Dev libraries
- What release is this for? Adding SDL2 support
- Is there a project or milestone we should apply this to? 0.9.x
