### PR TITLE
Enhancement: Document building on Arch

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1505,6 +1505,33 @@ function bootstrapOnFuntoo ()
         make
 }
 
+function bootstrapOnArch ()
+{
+  pacman -Sy --noconfirm \
+        cmake \
+        boost \
+        llvm \
+        clang \
+        gcc \
+        sdl \
+        sdl2 \
+        expat \
+        gtk3 \
+        libglvnd \
+        mesa \
+        python \
+        autoconf \
+        automake \
+        freeglut \
+        git \
+        libjpeg-turbo \
+        libpng \
+        libvorbis \
+        libxmu \
+        openal \
+        make
+}
+
 case "${LINUX_ID}" in
   "debian")
     bootstrapOnDebian
@@ -1541,6 +1568,9 @@ case "${LINUX_ID}" in
     ;;
   "funtoo")
     bootstrapOnFuntoo
+    ;;
+  "arch")
+    bootstrapOnArch
     ;;
   *)
     echo "Sorry, unrecognized/unsupported Linux distribution"

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1507,12 +1507,16 @@ function bootstrapOnFuntoo ()
 
 function bootstrapOnArch ()
 {
+  # NOTE: Arch requires GCC 12 right now
+  # also installing latest GCC.
   pacman -Sy --noconfirm \
+        base-devel \
         cmake \
         boost \
         llvm \
         clang \
         gcc \
+        gcc12 \
         sdl \
         sdl2 \
         expat \
@@ -1520,8 +1524,6 @@ function bootstrapOnArch ()
         libglvnd \
         mesa \
         python \
-        autoconf \
-        automake \
         freeglut \
         git \
         libjpeg-turbo \


### PR DESCRIPTION
This mainly makes it easy to locally build an Arch image for testing.

Thank you for submitting a pull request and becoming a contributor to Vega Strike's Build System Docker Images.

Please answer the following:

Code Changes:
- [ ] This is a documentation change only
- [ ] CI Change
- [x] Dev Support Change

Issues:
- n/a
- 
Purpose:
- Give devs the ability to make a docker image supporting Arch for testing purposes to help with triage/build issues on Arch.