### PR TITLE
script/bootstrap: Omit SDL 1 and 1.2

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -30,7 +30,7 @@
 set -e
 
 echo "------------------------------"
-echo "--- bootstrap | 2025-04-08 ---"
+echo "--- bootstrap | 2025-08-13 ---"
 echo "------------------------------"
 
 UPDATE_ALL_SYSTEM_PACKAGES="$1"
@@ -82,7 +82,6 @@ function bootstrapOnDebian()
                             libvorbis-dev \
                             libglvnd-dev \
                             libgl1-mesa-dev \
-                            libsdl1.2-dev \
                             libsdl2-dev \
                             libpostproc-dev \
                             freeglut3-dev \
@@ -122,7 +121,6 @@ function bootstrapOnDebian()
                             libvorbis-dev \
                             libglvnd-dev \
                             libgl1-mesa-dev \
-                            libsdl1.2-dev \
                             libsdl2-dev \
                             libpostproc-dev \
                             freeglut3-dev \
@@ -177,7 +175,6 @@ function bootstrapOnUbuntu()
                             libvorbis-dev \
                             libglvnd-dev \
                             libgl1-mesa-dev \
-                            libsdl1.2-dev \
                             libsdl2-dev \
                             libopengl0 \
                             libpostproc-dev \
@@ -237,7 +234,6 @@ function bootstrapOnPopOS ()
                             libvorbis-dev \
                             libglvnd-dev \
                             libgl1-mesa-dev \
-                            libsdl1.2-dev \
                             libsdl2-dev \
                             libopengl0 \
                             libpostproc-dev \
@@ -289,7 +285,6 @@ function bootstrapOnLinuxMint ()
                             libvorbis-dev \
                             libglvnd-dev \
                             libgl1-mesa-dev \
-                            libsdl1.2-compat-dev \
                             libsdl2-dev \
                             libopengl0 \
                             libpostproc-dev \
@@ -339,8 +334,6 @@ function bootstrapOnOpenSuseLeap ()
                                     freeglut-devel \
                                     libopenal0 \
                                     openal-soft-devel \
-                                    libSDL-1_2-0 \
-                                    libSDL-devel \
                                     libSDL2-devel \
                                     libvorbis-devel \
                                     libglvnd-devel \
@@ -379,7 +372,6 @@ function bootstrapOnFedora ()
                                 freeglut-devel \
                                 gcc-c++ \
                                 openal-soft-devel \
-                                sdl12-compat-devel \
                                 SDL2-devel \
                                 libvorbis-devel \
                                 libglvnd-devel \
@@ -401,7 +393,6 @@ function bootstrapOnFedora ()
                                 freeglut-devel \
                                 gcc-c++ \
                                 openal-soft-devel \
-                                sdl12-compat-devel \
                                 SDL2-devel \
                                 libvorbis-devel \
                                 libglvnd-devel \
@@ -423,7 +414,6 @@ function bootstrapOnFedora ()
                                 freeglut-devel \
                                 gcc-c++ \
                                 openal-soft-devel \
-                                sdl12-compat-devel \
                                 SDL2-devel \
                                 libvorbis-devel \
                                 libglvnd-devel \
@@ -460,7 +450,6 @@ function bootstrapOnCentOS ()
                                 freeglut-devel \
                                 gcc-c++ \
                                 openal-soft-devel \
-                                sdl12-compat-devel \
                                 SDL2-devel \
                                 libvorbis-devel \
                                 libglvnd-devel \
@@ -496,7 +485,6 @@ function bootstrapOnRedHat ()
                                 freeglut-devel \
                                 gcc-c++ \
                                 openal-soft-devel \
-                                sdl12-compat-devel \
                                 SDL2-devel \
                                 libvorbis-devel \
                                 libglvnd-devel \
@@ -533,7 +521,6 @@ function bootstrapOnRockyLinux ()
                                 freeglut-devel \
                                 gcc-c++ \
                                 openal-soft-devel \
-                                sdl12-compat-devel \
                                 SDL2-devel \
                                 libvorbis-devel \
                                 libglvnd-devel \
@@ -561,7 +548,6 @@ function bootstrapOnManjaro ()
                          clang \
                          gcc \
                          gcc-libs \
-                         sdl \
                          sdl2 \
                          expat \
                          gtk3 \
@@ -590,7 +576,6 @@ function bootstrapOnFuntoo ()
     USE="-libffi -userland_GNU gles2 X" emerge --autounmask-write \
               cmake \
               boost \
-              libsdl \
               libsdl2 \
               expat \
               gtk3 \
@@ -623,7 +608,6 @@ function bootstrapOnArch ()
               clang \
               gcc \
               gcc12 \
-              sdl \
               sdl2 \
               expat \
               gtk3 \


### PR DESCRIPTION
Code Changes:
- [x] CI Change

Issues:
- N/A

Purpose:
- What is this pull request trying to do? Drop the SDL 1 and 1.2 packages; everything current uses SDL 2
- What release is this for? 0.9.x and up
- Is there a project or milestone we should apply this to? Not sure
