### PR TITLE
.github/workflows: Set permissions for each workflow to read-only

### DIFF
--- a/.github/workflows/Anchore-Container-Scan.yml
+++ b/.github/workflows/Anchore-Container-Scan.yml
@@ -1,4 +1,7 @@
 name: Anchore-Container-Scan
+permissions:
+  contents: read
+  pull-requests: read
 
 # Controls when the action will run.
 on:

--- a/.github/workflows/fortify-on-demand-scan.yml
+++ b/.github/workflows/fortify-on-demand-scan.yml
@@ -1,4 +1,7 @@
 name: Fortify on Demand Scan
+permissions:
+  contents: read
+  pull-requests: read
 
 # Controls when the action will run.
 on:

--- a/.github/workflows/gh-actions-pr.yml
+++ b/.github/workflows/gh-actions-pr.yml
@@ -1,4 +1,7 @@
 name: 'GH Actions - PR'
+permissions:
+  contents: read
+  pull-requests: read
 
 on: [ pull_request ]
 

--- a/.github/workflows/gh-actions-release.yml
+++ b/.github/workflows/gh-actions-release.yml
@@ -1,4 +1,7 @@
 name: 'GH Actions - Release'
+permissions:
+  contents: read
+  pull-requests: read
 
 on:
   release:


### PR DESCRIPTION
Code Changes:
- [x] CI Change

Issues:
- Fixes some security findings

Purpose:
- What is this pull request trying to do? Fix some code scanning alerts about our GH workflows not having permissions assigned
- What release is this for? Any and all
- Is there a project or milestone we should apply this to? Probably not
