### PR TITLE
Add openSUSE Leap 16.0 RC to our matrix of build system docker images

### DIFF
--- a/.github/workflows/Anchore-Container-Scan.yml
+++ b/.github/workflows/Anchore-Container-Scan.yml
@@ -28,6 +28,7 @@ jobs:
           - 'linuxmintd/mint22-amd64'
           - 'debian:trixie'
           - 'debian:bookworm'
+          - 'opensuse/leap:16.0'
           - 'opensuse/leap:15.6'
           - 'fedora:42'
           - 'fedora:41'

--- a/.github/workflows/gh-actions-pr.yml
+++ b/.github/workflows/gh-actions-pr.yml
@@ -18,6 +18,7 @@ jobs:
           - 'linuxmintd/mint22-amd64'
           - 'debian:trixie'
           - 'debian:bookworm'
+          - 'opensuse/leap:16.0'
           - 'opensuse/leap:15.6'
           - 'fedora:42'
           - 'fedora:41'

--- a/.github/workflows/gh-actions-release.yml
+++ b/.github/workflows/gh-actions-release.yml
@@ -25,6 +25,7 @@ jobs:
           - 'linuxmintd/mint22-amd64'
           - 'debian:trixie'
           - 'debian:bookworm'
+          - 'opensuse/leap:16.0'
           - 'opensuse/leap:15.6'
           - 'fedora:42'
           - 'fedora:41'

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -30,7 +30,7 @@
 set -e
 
 echo "------------------------------"
-echo "--- bootstrap | 2025-08-13 ---"
+echo "--- bootstrap | 2025-09-02 ---"
 echo "------------------------------"
 
 UPDATE_ALL_SYSTEM_PACKAGES="$1"
@@ -329,6 +329,40 @@ function bootstrapOnOpenSuseLeap ()
                                     libboost_json1_75_0-devel \
                                     libboost_container1_75_0-devel \
                                     libboost_program_options1_75_0-devel \
+                                    cmake \
+                                    gcc-c++ \
+                                    freeglut-devel \
+                                    libopenal0 \
+                                    openal-soft-devel \
+                                    libSDL2-devel \
+                                    libvorbis-devel \
+                                    libglvnd-devel \
+                                    libjpeg-turbo \
+                                    libjpeg62-devel \
+                                    libpng16-devel \
+                                    libarchive-devel \
+                                    expat \
+                                    libexpat-devel \
+                                    libgtk-3-0 \
+                                    gtk3-devel \
+                                    python3-devel \
+                                    git \
+                                    rpm-build \
+                                    clang
+            ;;
+        "16.0")
+            zypper --non-interactive install -y \
+                                    libboost_log1_86_0-devel \
+                                    libboost_python-py3-1_86_0-devel \
+                                    libboost_system1_86_0-devel \
+                                    libboost_filesystem1_86_0-devel \
+                                    libboost_thread1_86_0-devel \
+                                    libboost_regex1_86_0-devel \
+                                    libboost_chrono1_86_0-devel \
+                                    libboost_atomic1_86_0-devel \
+                                    libboost_json1_86_0-devel \
+                                    libboost_container1_86_0-devel \
+                                    libboost_program_options1_86_0-devel \
                                     cmake \
                                     gcc-c++ \
                                     freeglut-devel \


### PR DESCRIPTION
Code Changes:
- [x] CI Change

Issues:
- N/A

Purpose:
- What is this pull request trying to do? Add openSUSE Leap 16.0 support
- What release is this for? 0.10.x and up
- Is there a project or milestone we should apply this to? 0.10.x?
