### PR TITLE
EndeavourOS troubleshooting

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -971,8 +971,9 @@ function bootstrapOnEndeavourOS ()
 {
     # NOTE: Arch requires GCC 12 right now
     # also installing latest GCC.
-    pacman -S --refresh --noconfirm \
+    pacman -Sy --refresh --noconfirm \
               base-devel \
+              icu \
               cmake \
               boost \
               llvm \


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to Vega Strike's Build System Docker Images.

Please answer the following:

Code Changes:
- [x] CI Change

Issues:
- Fixes #69 

Purpose:
- What is this pull request trying to do? Fix an issue that is cropping up when attempting to use the EndeavourOS build system Docker image -- specifically, an error about libicuuc.so.78 missing
- What release is this for? 0.10.x and later, primarily
- Is there a project or milestone we should apply this to? 0.10.x?
