### PR TITLE
More on EndeavourOS; add CentOS Stream 9 and 10

### DIFF
--- a/.github/workflows/Anchore-Container-Scan.yml
+++ b/.github/workflows/Anchore-Container-Scan.yml
@@ -37,6 +37,8 @@ jobs:
           - 'fedora:42'
           - 'fedora:41'
           - 'fedora:40'
+          - 'dokken/centos-stream-10:main'
+          - 'dokken/centos-stream-9:main'
           - 'rockylinux/rockylinux:10.0'
           - 'rockylinux/rockylinux:9.6'
           - 'rockylinux/rockylinux:9.5'

--- a/.github/workflows/gh-actions-pr.yml
+++ b/.github/workflows/gh-actions-pr.yml
@@ -27,6 +27,8 @@ jobs:
           - 'fedora:42'
           - 'fedora:41'
           - 'fedora:40'
+          - 'dokken/centos-stream-10:main'
+          - 'dokken/centos-stream-9:main'
           - 'rockylinux/rockylinux:10.0'
           - 'rockylinux/rockylinux:9.6'
           - 'rockylinux/rockylinux:9.5'

--- a/.github/workflows/gh-actions-release.yml
+++ b/.github/workflows/gh-actions-release.yml
@@ -34,6 +34,8 @@ jobs:
           - 'fedora:42'
           - 'fedora:41'
           - 'fedora:40'
+          - 'dokken/centos-stream-10:main'
+          - 'dokken/centos-stream-9:main'
           - 'rockylinux/rockylinux:10.0'
           - 'rockylinux/rockylinux:9.6'
           - 'rockylinux/rockylinux:9.5'

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -590,10 +590,9 @@ function bootstrapOnFedora ()
 function bootstrapOnCentOS ()
 {
     case "${LINUX_VERSION_ID}" in
-        "9.5")
+        "9")
             dnf -y install dnf-plugins-core
             dnf config-manager --set-enabled crb
-            dnf config-manager --set-enabled devel
             dnf -y install epel-release
             dnf -y update
             dnf -y install \
@@ -619,36 +618,7 @@ function bootstrapOnCentOS ()
                                 make \
                                 clang
             ;;
-        "9.6")
-            dnf -y install dnf-plugins-core
-            dnf config-manager --set-enabled crb
-            dnf config-manager --set-enabled devel
-            dnf -y install epel-release
-            dnf -y update
-            dnf -y install \
-                                git \
-                                cmake \
-                                boost-devel \
-                                boost-python3-devel \
-                                boost-json \
-                                freeglut-devel \
-                                gcc-c++ \
-                                openal-soft-devel \
-                                SDL2-devel \
-                                SDL2_image-devel \
-                                libvorbis-devel \
-                                libglvnd-devel \
-                                libjpeg-turbo-devel \
-                                libpng-devel \
-                                expat-devel \
-                                gtk3-devel \
-                                python3-devel \
-                                libarchive-devel \
-                                rpm-build \
-                                make \
-                                clang
-            ;;
-        "10.0")
+        "10")
             dnf -y upgrade --refresh
             dnf -y install 'dnf-command(config-manager)'
             dnf -y config-manager --set-enabled crb

--- a/script/local-test-ci.sh
+++ b/script/local-test-ci.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export FROM="debian:bullseye"
+export FROM="dokken/centos-stream-10:main"
 export MY_OS_NAME="linux"
 export IS_RELEASE=0
 


### PR DESCRIPTION
script/bootstrap: Change RHEL bootstrap sequence to match Rocky Linux's. Condition full system upgrade on `UPDATE_ALL_SYSTEM_PACKAGES` value on Arch Linux, Manjaro Linux, and EndeavourOS. Hopefully fix EndeavourOS builds in the process.

Add CentOS Stream 9 and 10 builds, and fix CentOS Stream bootstrap sequence.

Thank you for submitting a pull request and becoming a contributor to Vega Strike's Build System Docker Images.

Please answer the following:

Code Changes:
- [x] CI Change

Issues:
- Closes #79 
- Closes #80 

Purpose:
- What is this pull request trying to do? Fix EndeavourOS builds; add CentOS Stream 9 and 10
- What release is this for? 0.10.x and later, primarily
- Is there a project or milestone we should apply this to? 0.10.x?
