### PR TITLE
Add Ubuntu Resolute; Linux Mint Zena; and Fedora 44

### DIFF
--- a/.github/workflows/Anchore-Container-Scan.yml
+++ b/.github/workflows/Anchore-Container-Scan.yml
@@ -25,6 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         FROM:
+          - 'ubuntu:resolute'
           - 'ubuntu:questing'
           - 'ubuntu:plucky'
           - 'ubuntu:noble'

--- a/.github/workflows/Anchore-Container-Scan.yml
+++ b/.github/workflows/Anchore-Container-Scan.yml
@@ -29,6 +29,8 @@ jobs:
           - 'ubuntu:questing'
           - 'ubuntu:plucky'
           - 'ubuntu:noble'
+          #- 'linuxmintd/mint23-amd64'
+          #- 'linuxmintd/mint22.3-amd64'
           #- 'linuxmintd/mint22.2-amd64'
           #- 'linuxmintd/mint22-amd64'
           - 'debian:trixie'

--- a/.github/workflows/Anchore-Container-Scan.yml
+++ b/.github/workflows/Anchore-Container-Scan.yml
@@ -29,7 +29,6 @@ jobs:
           - 'ubuntu:questing'
           - 'ubuntu:plucky'
           - 'ubuntu:noble'
-          #- 'linuxmintd/mint23-amd64'
           #- 'linuxmintd/mint22.3-amd64'
           #- 'linuxmintd/mint22.2-amd64'
           #- 'linuxmintd/mint22-amd64'

--- a/.github/workflows/Anchore-Container-Scan.yml
+++ b/.github/workflows/Anchore-Container-Scan.yml
@@ -37,6 +37,7 @@ jobs:
           - 'debian:bookworm'
           - 'opensuse/leap:16.0'
           - 'opensuse/leap:15.6'
+          - 'fedora:44'
           - 'fedora:43'
           - 'fedora:42'
           - 'rockylinux/rockylinux:10.1'

--- a/.github/workflows/gh-actions-pr.yml
+++ b/.github/workflows/gh-actions-pr.yml
@@ -18,7 +18,6 @@ jobs:
           - 'ubuntu:questing'
           - 'ubuntu:plucky'
           - 'ubuntu:noble'
-          - 'linuxmintd/mint23-amd64'
           - 'linuxmintd/mint22.3-amd64'
           - 'linuxmintd/mint22.2-amd64'
           - 'linuxmintd/mint22-amd64'

--- a/.github/workflows/gh-actions-pr.yml
+++ b/.github/workflows/gh-actions-pr.yml
@@ -26,6 +26,7 @@ jobs:
           - 'debian:bookworm'
           - 'opensuse/leap:16.0'
           - 'opensuse/leap:15.6'
+          - 'fedora:44'
           - 'fedora:43'
           - 'fedora:42'
           - 'rockylinux/rockylinux:10.1'

--- a/.github/workflows/gh-actions-pr.yml
+++ b/.github/workflows/gh-actions-pr.yml
@@ -18,6 +18,8 @@ jobs:
           - 'ubuntu:questing'
           - 'ubuntu:plucky'
           - 'ubuntu:noble'
+          - 'linuxmintd/mint23-amd64'
+          - 'linuxmintd/mint22.3-amd64'
           - 'linuxmintd/mint22.2-amd64'
           - 'linuxmintd/mint22-amd64'
           - 'debian:trixie'

--- a/.github/workflows/gh-actions-pr.yml
+++ b/.github/workflows/gh-actions-pr.yml
@@ -14,6 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         FROM:
+          - 'ubuntu:resolute'
           - 'ubuntu:questing'
           - 'ubuntu:plucky'
           - 'ubuntu:noble'

--- a/.github/workflows/gh-actions-release.yml
+++ b/.github/workflows/gh-actions-release.yml
@@ -32,6 +32,7 @@ jobs:
           - 'debian:bookworm'
           - 'opensuse/leap:16.0'
           - 'opensuse/leap:15.6'
+          - 'fedora:44'
           - 'fedora:43'
           - 'fedora:42'
           - 'rockylinux/rockylinux:10.1'

--- a/.github/workflows/gh-actions-release.yml
+++ b/.github/workflows/gh-actions-release.yml
@@ -24,6 +24,8 @@ jobs:
           - 'ubuntu:questing'
           - 'ubuntu:plucky'
           - 'ubuntu:noble'
+          - 'linuxmintd/mint23-amd64'
+          - 'linuxmintd/mint22.3-amd64'
           - 'linuxmintd/mint22.2-amd64'
           - 'linuxmintd/mint22-amd64'
           - 'debian:trixie'

--- a/.github/workflows/gh-actions-release.yml
+++ b/.github/workflows/gh-actions-release.yml
@@ -24,7 +24,6 @@ jobs:
           - 'ubuntu:questing'
           - 'ubuntu:plucky'
           - 'ubuntu:noble'
-          - 'linuxmintd/mint23-amd64'
           - 'linuxmintd/mint22.3-amd64'
           - 'linuxmintd/mint22.2-amd64'
           - 'linuxmintd/mint22-amd64'

--- a/.github/workflows/gh-actions-release.yml
+++ b/.github/workflows/gh-actions-release.yml
@@ -20,6 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         FROM:
+          - 'ubuntu:resolute'
           - 'ubuntu:questing'
           - 'ubuntu:plucky'
           - 'ubuntu:noble'

--- a/script/bootstrap-on-linux.sh
+++ b/script/bootstrap-on-linux.sh
@@ -221,7 +221,7 @@ function bootstrapOnUbuntu()
     fi
 
     case "$LINUX_CODENAME" in
-        "questing"|"plucky")
+        "resolute|questing"|"plucky")
             apt-get -qy install \
                             git \
                             cmake \

--- a/script/bootstrap-on-linux.sh
+++ b/script/bootstrap-on-linux.sh
@@ -375,7 +375,7 @@ function bootstrapOnLinuxMint ()
 
     echo "Linux Mint base Distros do NOT support SDL3"
     case "$LINUX_CODENAME" in
-        "wilma"|"zara")
+        "wilma"|"zara"|"zena"|"alfa")
             apt-get -qy install \
                             git \
                             cmake \

--- a/script/bootstrap-on-linux.sh
+++ b/script/bootstrap-on-linux.sh
@@ -589,7 +589,7 @@ function bootstrapOnOpenSuseLeap ()
 function bootstrapOnFedora ()
 {
     export fedoraVersion=${LINUX_VERSION_ID}
-    export fedoraMaxSupportedVersion=43
+    export fedoraMaxSupportedVersion=44
     export fedoraMinSupportedVersion=42
     if [ ${fedoraVersion} -gt ${fedoraMaxSupportedVersion} ]
     then

--- a/script/bootstrap-on-linux.sh
+++ b/script/bootstrap-on-linux.sh
@@ -113,7 +113,6 @@ function bootstrapOnDebian()
                             libsdl2-image-dev \
                             libsdl3-dev \
                             libsdl3-image-dev \
-                            libpostproc-dev \
                             freeglut3-dev \
                             libboost-python-dev \
                             libboost-log-dev \
@@ -185,7 +184,6 @@ function bootstrapOnDebian()
                             libgl1-mesa-dev \
                             libsdl2-dev \
                             libsdl2-image-dev \
-                            libpostproc-dev \
                             freeglut3-dev \
                             libboost-python1.81-dev \
                             libboost-log1.81-dev \
@@ -272,7 +270,6 @@ function bootstrapOnUbuntu()
                             libsdl2-image-dev \
                             libsdl3-dev \
                             libsdl3-image-dev \
-                            libpostproc-dev \
                             freeglut3-dev \
                             libboost-python-dev \
                             libboost-log-dev \
@@ -338,7 +335,6 @@ function bootstrapOnUbuntu()
                             libgl1-mesa-dev \
                             libsdl2-dev \
                             libsdl2-image-dev \
-                            libpostproc-dev \
                             freeglut3-dev \
                             libboost-python-dev \
                             libboost-log-dev \
@@ -424,7 +420,6 @@ function bootstrapOnLinuxMint ()
                             libgl1-mesa-dev \
                             libsdl2-dev \
                             libsdl2-image-dev \
-                            libpostproc-dev \
                             freeglut3-dev \
                             libboost-python-dev \
                             libboost-log-dev \

--- a/script/bootstrap-on-linux.sh
+++ b/script/bootstrap-on-linux.sh
@@ -221,7 +221,7 @@ function bootstrapOnUbuntu()
     fi
 
     case "$LINUX_CODENAME" in
-        "resolute|questing"|"plucky")
+        "resolute"|"questing"|"plucky")
             apt-get -qy install \
                             git \
                             cmake \


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to Vega Strike's Build System Docker Images.

Please answer the following:

Code Changes:
- [x] CI Change

Issues Addressed:
- N/A

Purpose:
- What is this pull request trying to do? Update the set of Linux versions we support to include Ubuntu 26.04 "Resolute"; Linux Mint 22.3 "Zena"; and Fedora 44.
- What release is this for? All upcoming releases
- Is there a project or milestone we should apply this to? 0.10.x, maybe?

Note: Linux Mint 23 "Alfa" had to be dropped, for now at least, as it was returning the wrong distribution/version information.