### PR TITLE
3x .github/workflows/*.yml: Add DHI SFW Python 3.14 images

### DIFF
--- a/.github/workflows/Anchore-Container-Scan.yml
+++ b/.github/workflows/Anchore-Container-Scan.yml
@@ -45,6 +45,7 @@ jobs:
           - 'rockylinux/rockylinux:9.6'
           - 'manjarolinux/base'
           - 'dhi.io/python:3.14-debian13-dev'
+          - 'dhi.io/python:3.14-debian13-sfw-dev'
           - 'dhi.io/python:3.13-debian13-dev'
           - 'dhi.io/python:3.13-debian13-sfw-dev'
           # - 'alex5402/endeavouros'

--- a/.github/workflows/linux-pr.yml
+++ b/.github/workflows/linux-pr.yml
@@ -35,6 +35,7 @@ jobs:
           - 'manjarolinux/base'
           - 'alex5402/endeavouros'
           - 'dhi.io/python:3.14-debian13-dev'
+          - 'dhi.io/python:3.14-debian13-sfw-dev'
           - 'dhi.io/python:3.13-debian13-dev'
           - 'dhi.io/python:3.13-debian13-sfw-dev'
           # - 'funtoo/stage3-generic_64'

--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -41,6 +41,7 @@ jobs:
           - 'manjarolinux/base'
           - 'alex5402/endeavouros'
           - 'dhi.io/python:3.14-debian13-dev'
+          - 'dhi.io/python:3.14-debian13-sfw-dev'
           - 'dhi.io/python:3.13-debian13-dev'
           - 'dhi.io/python:3.13-debian13-sfw-dev'
           #- 'funtoo/stage3-generic_64'


### PR DESCRIPTION
Thank you for submitting a pull request and becoming a contributor to Vega Strike's Build System Docker Images.

Please answer the following:

Code Changes:
- [x] CI Change

Issues:
- N/A

Purpose:
- What is this pull request trying to do? Add the Socket Firewall Lite Python 3.14.x Docker Hardened Image variant, which fixes a critical vulnerability present in Python 3.13.x
- What release is this for? Any
- Is there a project or milestone we should apply this to? Probably not
